### PR TITLE
Remove `float` property from blacklist

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,6 @@ module.exports = {
 				]
 			}
 		],
-		'property-blacklist': [
-			'float'
-		],
 		'property-no-vendor-prefix': [
 			true,
 			{


### PR DESCRIPTION
Though I could see rationale behind this for encouraging flexbox only usage, it is still common on some sites to float images around text so they wrap