### PR TITLE
Blacklist rgb/rgba functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,9 @@ module.exports = {
 		'function-parentheses-space-inside': 'never',
 		'function-url-quotes': 'always',
 		'function-whitespace-after': 'always',
+		'function-blacklist': [
+			/^rgb/
+		],
 		'number-leading-zero': 'always',
 		'number-no-trailing-zeros': true,
 		'string-quotes': [


### PR DESCRIPTION
I found this code:

```css
:root {
	--background-color: #fff;
	--text-color: #202124;
	--secondary-text-color: #5f6368;
	--link-color: #3367d6;
	--input-border-color: rgba(0, 0, 0, 0.2);
}
```

The last value didn't have to use `rgba()` just to add the alpha value, it should have been

```css
:root {
	--background-color: #fff;
	--text-color: #202124;
	--secondary-text-color: #5f6368;
	--link-color: #3367d6;
	--input-border-color: #00000033;
}
```

`rgba` has historically been mainly used because hex colors didn't support transparency, so you had no choice but convert your hex colors to `rgba()`

Now browsers support transparency in hex colors as well, so rgb/rgba offers little compared to the shorter hex representation.