### PR TITLE
Allow -moz-tab-size

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,8 +81,7 @@ module.exports = {
 			{
 				ignoreValues: [
 					'grab',
-					'grabbing',
-					'tab-size' // It's still only prefixed in Firefox
+					'grabbing'
 				]
 			}
 		],
@@ -93,7 +92,7 @@ module.exports = {
 					'app-region', // For Electron
 					'appearance',
 					'mask',
-					'tab-size'
+					'tab-size' // It's still only prefixed in Firefox
 				]
 			}
 		],

--- a/index.js
+++ b/index.js
@@ -92,7 +92,8 @@ module.exports = {
 				ignoreProperties: [
 					'app-region', // For Electron
 					'appearance',
-					'mask'
+					'mask',
+					'tab-size'
 				]
 			}
 		],


### PR DESCRIPTION
I'm not sure of what's the logic for allowing properties here, but how about `-moz-tab-size`?

Prefix-less `tab-size` is [still not allowed](https://bugzilla.mozilla.org/show_bug.cgi?id=737785) in Firefox.