### PR TITLE
Remove rule that was removed in Stylelint 14

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ module.exports = {
 		'color-no-invalid-hex': true,
 		'font-family-no-duplicate-names': true,
 		'font-family-no-missing-generic-family-keyword': true,
-		'function-calc-no-invalid': true,
 		'function-calc-no-unspaced-operator': true,
 		'function-linear-gradient-no-nonstandard-direction': true,
 		'string-no-newline': true,


### PR DESCRIPTION
Users of this cannot migrate to StyleLint 14 since this option was removed. I can update the version in package.json as well, but the config still works for 13.7.0, so I didn't.