### PR TITLE
Allow `border-radius: 0;`

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = {
 		],
 		'declaration-no-important': true,
 		'declaration-property-value-disallowed-list': {
-			'/^border(?!-(width|spacing))/': [
+			'/^border(?!-(width|spacing|radius|(top|bottom)-(left|right)-radius))/': [
 				/thin/,
 				/medium/,
 				/thick/,


### PR DESCRIPTION
`border-radius`, `border-top-left-radius` and similar properties are currently not allowed by this Stylelint config to have a `0` value, with the comment to use `none` instead. However, the `none` keyword is not allowed in the CSS standard: https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius#syntax

This PR excludes `border-radius`, `border-top-left-radius`, etc. from this disallowed value list.