### PR TITLE
Drop stylistic rules for style lint v15

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,6 @@ module.exports = {
 		'no-duplicate-at-import-rules': true,
 		'no-duplicate-selectors': true,
 		'no-empty-source': true,
-		'no-extra-semicolons': true,
 		'no-invalid-double-slash-comments': true,
 		'alpha-value-notation': 'percentage',
 		'hue-degree-notation': 'angle',
@@ -116,7 +115,6 @@ module.exports = {
 		'selector-max-attribute': 8,
 		'selector-max-class': 8,
 		'selector-max-compound-selectors': 8,
-		'selector-max-empty-lines': 0,
 		'selector-max-universal': 1,
 		'selector-no-vendor-prefix': [
 			true,
@@ -157,68 +155,17 @@ module.exports = {
 				]
 			}
 		],
-		'color-hex-case': 'lower',
 		'color-hex-length': 'short',
 		'font-family-name-quotes': 'always-where-recommended',
 		'font-weight-notation': 'named-where-possible',
-		'function-comma-newline-after': 'always-multi-line',
-		'function-comma-newline-before': 'never-multi-line',
-		'function-comma-space-after': 'always-single-line',
-		'function-max-empty-lines': 0,
 		'function-name-case': 'lower',
-		'function-parentheses-newline-inside': 'always-multi-line',
-		'function-parentheses-space-inside': 'never-single-line',
 		'function-url-quotes': 'always',
-		'function-whitespace-after': 'always',
-		'number-leading-zero': 'always',
-		'number-no-trailing-zeros': true,
-		'string-quotes': [
-			'single',
-			{
-				avoidEscape: false
-			}
-		],
 		'length-zero-no-unit': true,
-		'unit-case': 'lower',
 		'value-keyword-case': 'lower',
-		'value-list-comma-newline-after': 'always-multi-line',
-		'value-list-comma-newline-before': 'never-multi-line',
-		'value-list-comma-space-after': 'always-single-line',
-		'value-list-comma-space-before': 'never',
-		'value-list-max-empty-lines': 0,
-		'property-case': 'lower',
-		'declaration-bang-space-after': 'never',
-		'declaration-bang-space-before': 'always',
-		'declaration-colon-newline-after': 'always-multi-line',
-		'declaration-colon-space-after': 'always-single-line',
-		'declaration-colon-space-before': 'never',
 		'declaration-empty-line-before': 'never',
-		'declaration-block-semicolon-newline-after': 'always',
-		'declaration-block-semicolon-newline-before': 'never-multi-line',
-		'declaration-block-semicolon-space-after': 'always-single-line',
-		'declaration-block-semicolon-space-before': 'never',
-		'declaration-block-trailing-semicolon': 'always',
-		'block-closing-brace-empty-line-before': 'never',
-		'block-closing-brace-newline-after': 'always',
-		'block-closing-brace-newline-before': 'always',
-		'block-opening-brace-newline-after': 'always',
-		'block-opening-brace-space-before': 'always',
-		'selector-attribute-brackets-space-inside': 'never',
-		'selector-attribute-operator-space-after': 'never',
-		'selector-attribute-operator-space-before': 'never',
 		'selector-attribute-quotes': 'always',
-		'selector-combinator-space-after': 'always',
-		'selector-combinator-space-before': 'always',
-		'selector-descendant-combinator-no-non-space': true,
-		'selector-pseudo-class-case': 'lower',
-		'selector-pseudo-class-parentheses-space-inside': 'never',
-		'selector-pseudo-element-case': 'lower',
 		'selector-pseudo-element-colon-notation': 'double',
 		'selector-type-case': 'lower',
-		'selector-list-comma-newline-after': 'always',
-		'selector-list-comma-newline-before': 'never-multi-line',
-		'selector-list-comma-space-after': 'always-single-line',
-		'selector-list-comma-space-before': 'never',
 		'rule-empty-line-before': [
 			'always',
 			{
@@ -231,15 +178,6 @@ module.exports = {
 				]
 			}
 		],
-		'media-feature-colon-space-after': 'always',
-		'media-feature-colon-space-before': 'never',
-		'media-feature-name-case': 'lower',
-		'media-feature-parentheses-space-inside': 'never',
-		'media-feature-range-operator-space-after': 'always',
-		'media-feature-range-operator-space-before': 'always',
-		'media-query-list-comma-newline-after': 'always',
-		'media-query-list-comma-newline-before': 'never-multi-line',
-		'media-query-list-comma-space-before': 'never',
 		'at-rule-empty-line-before': [
 			'always',
 			{
@@ -252,24 +190,7 @@ module.exports = {
 				]
 			}
 		],
-		'at-rule-name-case': 'lower',
-		'at-rule-name-newline-after': 'always-multi-line',
-		'at-rule-name-space-after': 'always-single-line',
-		'at-rule-semicolon-newline-after': 'always',
-		'at-rule-semicolon-space-before': 'never',
 		'comment-whitespace-inside': 'always',
-		indentation: [
-			'tab',
-			{
-				baseIndentLevel: 1
-			}
-		],
-		linebreaks: 'unix',
-		'max-empty-lines': 2,
-		'no-eol-whitespace': true,
-		'no-missing-end-of-source-newline': true,
-		'no-empty-first-line': true,
-		'unicode-bom': 'never',
 
 		// `stylelint-order`
 		'order/order': [

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
 	},
 	"devDependencies": {
 		"ava": "^4.1.0",
-		"stylelint": "^14.5.3",
+		"stylelint": "^15.10.3",
 		"xo": "^0.31.0"
 	},
 	"peerDependencies": {
-		"stylelint": ">=14"
+		"stylelint": ">=15"
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -27,10 +27,11 @@ const runStylelint = async code => {
 test('main', async t => {
 	const results = await runStylelint(
 		`div {
-			left: .2em;
+			/*nospaces*/
+			left: 0.2em;
 		}
 		`
 	);
 
-	t.true(hasRule(results[0].warnings, 'number-leading-zero'));
+	t.true(hasRule(results[0].warnings, 'comment-whitespace-inside'));
 });


### PR DESCRIPTION
- Closes https://github.com/xojs/stylelint-config-xo/issues/19


Procedure:

1. I did a search and replace with this regex:

```
'(at-rule-name-case|at-rule-name-newline-after|at-rule-semicolon-space-before|at-rule-name-space-after|at-rule-semicolon-newline-after|block-closing-brace-empty-line-before|block-closing-brace-newline-after|block-closing-brace-newline-before|block-opening-brace-newline-after|block-opening-brace-space-before|color-hex-case|declaration-bang-space-after|declaration-bang-space-before|declaration-block-semicolon-newline-after|declaration-block-semicolon-newline-before|declaration-block-semicolon-space-after|declaration-block-semicolon-space-before|declaration-block-trailing-semicolon|declaration-colon-newline-after|declaration-colon-space-after|declaration-colon-space-before|function-comma-newline-after|function-comma-newline-before|function-comma-space-after|function-max-empty-lines|function-parentheses-newline-inside|function-parentheses-space-inside|function-whitespace-after|linebreaks|max-empty-lines|media-feature-colon-space-after|media-feature-colon-space-before|media-feature-name-case|media-feature-parentheses-space-inside|media-feature-range-operator-space-after|media-feature-range-operator-space-before|media-query-list-comma-newline-after|media-query-list-comma-newline-before|media-query-list-comma-space-before|no-empty-first-line|no-eol-whitespace|no-extra-semicolons|no-missing-end-of-source-newline|number-leading-zero|number-no-trailing-zeros|property-case|selector-attribute-brackets-space-inside|selector-attribute-operator-space-after|selector-attribute-operator-space-before|selector-combinator-space-after|selector-combinator-space-before|selector-descendant-combinator-no-non-space|selector-list-comma-newline-after|selector-list-comma-newline-before|selector-list-comma-space-after|selector-list-comma-space-before|selector-max-empty-lines|selector-pseudo-class-case|selector-pseudo-class-parentheses-space-inside|selector-pseudo-element-case|string-quotes|unicode-bom|unit-case|value-list-comma-newline-after|value-list-comma-newline-before|value-list-comma-space-after|value-list-comma-space-before|value-list-max-empty-lines|indentation)': [^,]+,
```

2. Ran another one without the `'` to find non-escaped properties
3. Fixed the single options object left behind 
4. Ran locally to ensure all deprecated rules were removed